### PR TITLE
Allocate PHP messages efficiently

### DIFF
--- a/main.php
+++ b/main.php
@@ -8,12 +8,7 @@ $worst = 0;
 
 function mkMessage($highID)
 {
-    $m = [];
-    for ($i = 0 ; $i < 1024 ; $i++) {
-        $m[$i] = $highID;
-    }
-
-    return $m;
+    return str_repeat(pack("C", $highID), 1024);
 }
 
 function pushMsg(&$channel, $highID) {


### PR DESCRIPTION
Hi @glutamatt. I noticed that this quickly ran out of memory when I attempted to runt it (required at least a gigabyte). I have optimized it to make the message creation more efficient. I'm not a PHP dev though; does what I've implemented make sense to you?