### PR TITLE
Update to ocaml 4.10

### DIFF
--- a/ocaml/Dockerfile
+++ b/ocaml/Dockerfile
@@ -1,8 +1,9 @@
-FROM ocaml/opam:debian-stable_ocaml-4.04.2
+FROM ocaml/opam2:4.10
 WORKDIR /home/opam/src
 COPY main.ml .
 COPY _tags .
 USER root
+RUN apt-get install -qy m4
 RUN chown -R opam:opam .
 USER opam
 RUN opam install batteries


### PR DESCRIPTION
The ocaml/opam was actually no longer working. ocaml/opam2 must
be used instead.

Fixes https://github.com/WillSewell/gc-latency-experiment/issues/21