### PR TITLE
Upgrade to openjdk 16 and use ZGC instead of G1

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u141
+FROM openjdk:16
 COPY Main.java .
 RUN javac Main.java
-ENTRYPOINT ["java", "-Xmx512m", "-XX:+PrintFlagsFinal", "-XX:+PrintGCTimeStamps", "-verbosegc", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=10", "-XX:ParallelGCThreads=2", "Main"]
+ENTRYPOINT ["java", "-Xmx512m", "-XX:+PrintFlagsFinal", "-verbosegc", "-XX:+UseZGC", "-XX:MaxGCPauseMillis=10", "-XX:ParallelGCThreads=2", "Main"]


### PR DESCRIPTION
I was inspired to try it out after reading this blog post: https://malloc.se/blog/zgc-jdk16.

It takes the pause times down from ~50ms to ~2ms on my laptop!