### PR TITLE
Refresh the OCaml version from 4.14 to 5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ java/results.txt: java/Dockerfile java/Main.java
 	docker build -t gc-java java
 	docker run gc-java > $@
 
-ocaml/results.txt: ocaml/Dockerfile ocaml/_tags ocaml/main.ml
+ocaml/results.txt: ocaml/Dockerfile ocaml/main.ml
 	docker build -t gc-ocaml ocaml
 	docker run gc-ocaml > $@
 

--- a/ocaml/Dockerfile
+++ b/ocaml/Dockerfile
@@ -1,11 +1,8 @@
 FROM ocaml/opam:debian-ocaml-4.14
 WORKDIR /home/opam/src
 COPY main.ml .
-COPY _tags .
 USER root
-RUN apt-get install -qy m4
 RUN chown -R opam:opam .
 USER opam
-RUN opam install batteries
-RUN eval $(opam config env) && ocamlbuild -use-ocamlfind main.native
+RUN eval $(opam config env) && ocamlopt unix.cmxa main.ml -o main.native
 ENTRYPOINT ["./main.native"]

--- a/ocaml/Dockerfile
+++ b/ocaml/Dockerfile
@@ -1,8 +1,8 @@
-FROM ocaml/opam:debian-ocaml-4.14
+FROM ocaml/opam:debian-ocaml-5.2
 WORKDIR /home/opam/src
 COPY main.ml .
 USER root
 RUN chown -R opam:opam .
 USER opam
-RUN eval $(opam config env) && ocamlopt unix.cmxa main.ml -o main.native
+RUN eval $(opam config env) && ocamlopt -I +unix unix.cmxa main.ml -o main.native
 ENTRYPOINT ["./main.native"]

--- a/ocaml/_tags
+++ b/ocaml/_tags
@@ -1,2 +1,0 @@
-<Main.*>: precious
-true: package(batteries)

--- a/ocaml/main.ml
+++ b/ocaml/main.ml
@@ -1,5 +1,3 @@
-open Batteries
-
 module IMap = Map.Make(Int)
 
 type msg = string
@@ -30,4 +28,4 @@ let () =
     |> Seq.fold_left push_msg IMap.empty
     |> ignore
   end;
-  Printf.printf "Worst pause: %.2E\n" !worst
+  Printf.printf "Worst push time: %.6fms\n" (!worst *. 1000.)


### PR DESCRIPTION
I looked at this again, I notice that more recent versions of OCaml give sensibly better worst-case latency, so I propose to update the result.

In this PR:
- the first commit simplifies the benchmarking setup by removing a dependency and simplifying the build system
- the second commit updates the OCaml version from 4.14 to 5.2

I haven't touched the README, I assume that you are doing this yourself?