### PR TITLE
Add haskell with GHC's nonmoving GC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RESULTS = d/results.txt go/results.txt haskell/results.txt java/results.txt ocaml/results.txt php/results.txt racket/results.txt ruby/results.txt node/results.txt dotnet/results.txt python/results.txt c/results.txt erlang/results.txt crystal/results.txt common-lisp/results-sbcl.txt common-lisp/results-sbcl.txt common-lisp/results-ecl-interp.txt common-lisp/results-ecl-compile.txt common-lisp/results-ccl.txt
+RESULTS = d/results.txt go/results.txt haskell/results.txt haskell-nonmoving/results.txt java/results.txt ocaml/results.txt php/results.txt racket/results.txt ruby/results.txt node/results.txt dotnet/results.txt python/results.txt c/results.txt erlang/results.txt crystal/results.txt common-lisp/results-sbcl.txt common-lisp/results-sbcl.txt common-lisp/results-ecl-interp.txt common-lisp/results-ecl-compile.txt common-lisp/results-ccl.txt
 
 .PHONY: all clean
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ haskell/results.txt: haskell/Dockerfile haskell/Main.hs
 	docker build -t gc-haskell haskell
 	docker run gc-haskell > $@
 
+haskell-nonmoving/results.txt: haskell-nonmoving/Dockerfile haskell-nonmoving/Main.hs
+	docker build -t gc-haskell-nonmoving haskell-nonmoving
+	docker run gc-haskell-nonmoving > $@
+
 java/results.txt: java/Dockerfile java/Main.java
 	docker build -t gc-java java
 	docker run gc-java > $@

--- a/haskell-nonmoving/Dockerfile
+++ b/haskell-nonmoving/Dockerfile
@@ -1,0 +1,6 @@
+FROM haskell:9.2
+COPY Main.hs .
+RUN ghc -threaded -O2 -optc-O3 Main.hs
+ENTRYPOINT ["./Main", "+RTS", "--nonmoving-gc"]
+
+# TODO make all output consistent

--- a/haskell-nonmoving/Main.hs
+++ b/haskell-nonmoving/Main.hs
@@ -1,0 +1,32 @@
+module Main (main) where
+  
+import qualified Control.Exception as Exception
+import qualified Control.Monad as Monad
+import qualified Data.Array.IO as Array
+import qualified Data.ByteString as ByteString
+import qualified Data.Time.Clock as Clock
+
+type Msg = ByteString.ByteString
+
+type Chan = Array.IOArray Int Msg
+
+windowSize = 200000
+msgCount = 1000000
+
+message :: Int -> Msg
+message n = ByteString.replicate 1024 (fromIntegral n)
+
+pushMsg :: Chan -> Clock.NominalDiffTime -> Int -> IO Clock.NominalDiffTime
+pushMsg chan worst highId = do
+    start <- Clock.getCurrentTime
+    m <- Exception.evaluate $ message highId
+    Array.writeArray chan (highId `mod` windowSize) m
+    end <- Clock.getCurrentTime
+    let elapsed = Clock.diffUTCTime end start
+    return $ max elapsed worst
+
+main :: IO ()
+main = do
+  c <- Array.newArray_ (0, windowSize)
+  worst <- Monad.foldM (pushMsg c) 0 [0..msgCount]
+  print worst


### PR DESCRIPTION
The nonmoving garbage collector of GHC was specifically developed to reduce pause times. It is interesting to compare its performance to GHC with the moving collector and to Golang (the alternative chosen by the article referenced in the README). In my machine I get the following results:

- Haskell with moving GC: ~250ms
- Haskell with nonmoving GC: 12.749385ms
- Golang: 15.274919ms

To enable the nonmoving GC, simply compile with `-threaded` and add `+RTS --nonmoving-gc` to the executable's runtime arguments.